### PR TITLE
Allow wrapping functions that depend on time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeDag"
 uuid = "91963e24-6e66-4132-aeb8-436d9f37dbc7"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/README.md
+++ b/README.md
@@ -7,4 +7,30 @@
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
-A computational graph for time-series processing. (WIP)
+A computational graph for time-series processing.
+
+```julia
+# Create nodes — lazy generators of time-series data.
+x = rand(pulse(Hour(2)))
+y = rand(pulse(Hour(3)))
+
+# Apply functions to nodes to make new nodes.
+z = cov(x, lag(y, 2))
+
+# Evaluate nodes over a time range to pull data through the graph.
+evaluate(z, DateTime(2021, 1, 1, 0), DateTime(2021, 1, 1, 15))
+```
+
+```
+Block{Float64}(5 knots)
+|                time |      value |
+|            DateTime |    Float64 |
+|---------------------|------------|
+| 2021-01-01T08:00:00 |        0.0 |
+| 2021-01-01T09:00:00 |  0.0245348 |
+| 2021-01-01T10:00:00 |  0.0100269 |
+| 2021-01-01T12:00:00 | 0.00183812 |
+| 2021-01-01T14:00:00 | 0.00559926 |
+```
+
+For more information and examples, see the [documentation](https://invenia.github.io/TimeDag.jl/stable).

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -731,7 +731,7 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 deps = ["AbstractTrees", "AssociativeWindowAggregation", "Bijections", "DataStructures", "Dates", "LightGraphs", "LinearAlgebra", "PrettyTables", "Random", "RecipesBase", "StaticArrays", "Statistics", "Tables", "TeaFiles"]
 path = "/Users/gillam/.julia/dev/TimeDag"
 uuid = "91963e24-6e66-4132-aeb8-436d9f37dbc7"
-version = "0.1.1"
+version = "0.1.2"
 
 [[TimeSeries]]
 deps = ["Dates", "DelimitedFiles", "DocStringExtensions", "RecipesBase", "Reexport", "Statistics", "Tables"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ CurrentModule = TimeDag
 
 Welcome to the documentation for [TimeDag.jl](https://github.com/invenia/TimeDag.jl)!
 
-`TimeDag.jl` enables you to build and run time-series models efficiently.
+`TimeDag` enables you to build and run time-series models efficiently.
 
 You might want to use this package if some of the following apply:
 * You are processing data with a natural time ordering.

--- a/docs/src/reference/creating_ops.md
+++ b/docs/src/reference/creating_ops.md
@@ -32,7 +32,7 @@ struct MySource <: TimeDag.NodeOp{Int64} end
 # Indicate that our source doesn't have any evaluation state.
 TimeDag.stateless(::MySource) = true
 
-TimeDag.run_node!(
+function TimeDag.run_node!(
     ::MySource, 
     ::TimeDag.EmptyNodeEvaluationState, 
     time_start::DateTime, 

--- a/docs/src/reference/fundamentals.md
+++ b/docs/src/reference/fundamentals.md
@@ -18,7 +18,7 @@ A node knows the type of its values, which can be queries with [`TimeDag.value_t
 Note that nodes should never be constructed directly by the user.
 Typically one will call a function like [`block_node`](@ref) or [`lag`](@ref), which will construct a node.
 
-`TimeDag.jl` includes functions to construct many useful nodes, but often you will need to create a custom node.
+`TimeDag` includes functions to construct many useful nodes, but often you will need to create a custom node.
 See `Creating nodes` for instructions on how to do this.
 
 !!! info

--- a/docs/src/reference/internals.md
+++ b/docs/src/reference/internals.md
@@ -6,13 +6,13 @@ Other parts shouldn't need to be regularly interacted with, but can be useful to
 
 ## Identity map
 
-One of the key features of `TimeDag.jl` is avoiding duplicating work.
+One of the key features of `TimeDag` is avoiding duplicating work.
 
 This is primarily achieved by ensuring that we never construct the 'same' node twice.
 By 'same', here we mean two nodes that we can prove will always give the same output.
 
 One easy-to-handle case is that of a node that has identical parents & op to another.
-To avoid this, `TimeDag.jl` maintains a global [identity map](https://en.wikipedia.org/wiki/Identity_map_pattern), of type [`TimeDag.IdentityMap`](@ref).
+To avoid this, `TimeDag` maintains a global [identity map](https://en.wikipedia.org/wiki/Identity_map_pattern), of type [`TimeDag.IdentityMap`](@ref).
 
 Currently the only implementation of the identity map is [`TimeDag.WeakIdentityMap`](@ref).
 This contains weak references to nodes, to ensure that we know about all nodes that currently exist, but don't unnecessarily prevent nodes from being garbage collected when we no longer want them.

--- a/src/alignment.jl
+++ b/src/alignment.jl
@@ -113,6 +113,8 @@ If this returns true, `create_operator_evaluation_state` will not be used.
 Note that if an `op` has `stateless(op)` returning true, then it necessarily should also
 return true here. The default implementation is to return `stateless(op)`, meaning that if
 one is creating a node that is fully stateless, one need only define `stateless`.
+
+For optimal performance, this should be knowable from the type of `op` alone.
 """
 stateless_operator(node::Node) = stateless_operator(node.op)
 stateless_operator(op::NodeOp) = stateless(op)
@@ -122,6 +124,8 @@ stateless_operator(op::NodeOp) = stateless(op)
     time_agnostic(op) -> Bool
 
 Returns true iff `op` does not care about the time of the input knot(s).
+
+For optimal performance, this should be knowable from the type of `op` alone.
 """
 time_agnostic(node::Node) = time_agnostic(node.op)
 time_agnostic(::NodeOp) = false
@@ -131,6 +135,8 @@ time_agnostic(::NodeOp) = false
     value_agnostic(op) -> Bool
 
 Returns true iff `op` does not care about the value(s) of the input knot(s).
+
+For optimal performance, this should be knowable from the type of `op` alone.
 """
 value_agnostic(node::Node) = value_agnostic(node.op)
 value_agnostic(::NodeOp) = false

--- a/src/ops/common.jl
+++ b/src/ops/common.jl
@@ -1,44 +1,56 @@
 """
-    SimpleUnary{f,T}
+    SimpleUnary{f,TimeAgnostic,T}
 
-Represents a stateless, time-independent unary operator that will always emit a value.
+Represents a stateless unary operator that will always emit a value.
+
+The value of the `TimeAgnostic` type parmater is coupled to [`time_agnostic`](@ref).
 """
-struct SimpleUnary{f,T} <: UnaryNodeOp{T} end
+struct SimpleUnary{f,TimeAgnostic,T} <: UnaryNodeOp{T} end
 
 always_ticks(::SimpleUnary) = true
 stateless_operator(::SimpleUnary) = true
-time_agnostic(::SimpleUnary) = true
-operator!(::SimpleUnary{f}, x) where {f} = f(x)
+time_agnostic(::SimpleUnary{f,false}) where {f} = false
+time_agnostic(::SimpleUnary{f,true}) where {f} = true
+operator!(::SimpleUnary{f,false}, t, x) where {f} = f(t, x)
+operator!(::SimpleUnary{f,true}, x) where {f} = f(x)
 
 """
-    SimpleBinary{f,T,A}
+    SimpleBinary{f,TimeAgnostic,T,A}
 
-Represents a stateless, time-independent binary operator that will always emit a value.
+Represents a stateless binary operator that will always emit a value.
+
+The value of the `TimeAgnostic` type parmater is coupled to [`time_agnostic`](@ref).
 """
-struct SimpleBinary{f,T,A} <: BinaryNodeOp{T,A} end
+struct SimpleBinary{f,TimeAgnostic,T,A} <: BinaryNodeOp{T,A} end
 
 always_ticks(::SimpleBinary) = true
 stateless_operator(::SimpleBinary) = true
-time_agnostic(::SimpleBinary) = true
-operator!(::SimpleBinary{f}, x, y) where {f} = f(x, y)
+time_agnostic(::SimpleBinary{f,false}) where {f} = false
+time_agnostic(::SimpleBinary{f,true}) where {f} = true
+operator!(::SimpleBinary{f,false}, t, x, y) where {f} = f(t, x, y)
+operator!(::SimpleBinary{f,true}, x, y) where {f} = f(x, y)
 
 """
-    SimpleBinaryUnionInitial{f,T,L,R}
+    SimpleBinaryUnionInitial{f,TimeAgnostic,T,L,R}
 
-Represents a stateless, time-independent binary operator that will always emit a value.
+Represents a stateless binary operator that will always emit a value.
+
+The value of the `TimeAgnostic` type parmater is coupled to [`time_agnostic`](@ref).
 
 Unlike [`SimpleBinary`](@ref), this also contains initial values for its parent nodes.
 See [Initial values](@ref) for more details.
 """
-struct SimpleBinaryUnionInitial{f,T,L,R} <: BinaryNodeOp{T,UnionAlignment}
+struct SimpleBinaryUnionInitial{f,TimeAgnostic,T,L,R} <: BinaryNodeOp{T,UnionAlignment}
     initial_l::L
     initial_r::R
 end
 
 always_ticks(::SimpleBinaryUnionInitial) = true
 stateless_operator(::SimpleBinaryUnionInitial) = true
-time_agnostic(::SimpleBinaryUnionInitial) = true
-operator!(::SimpleBinaryUnionInitial{f}, x, y) where {f} = f(x, y)
+time_agnostic(::SimpleBinaryUnionInitial{f,false}) where {f} = false
+time_agnostic(::SimpleBinaryUnionInitial{f,true}) where {f} = true
+operator!(::SimpleBinaryUnionInitial{f,false}, t, x, y) where {f} = f(t, x, y)
+operator!(::SimpleBinaryUnionInitial{f,true}, x, y) where {f} = f(x, y)
 has_initial_values(::SimpleBinaryUnionInitial) = true
 initial_left(op::SimpleBinaryUnionInitial) = op.initial_l
 initial_right(op::SimpleBinaryUnionInitial) = op.initial_r
@@ -46,66 +58,80 @@ initial_right(op::SimpleBinaryUnionInitial) = op.initial_r
 """
     SimpleBinaryLeftInitial{f,T,R}
 
-Represents a stateless, time-independent binary operator that will always emit a value.
+Represents a stateless binary operator that will always emit a value.
+
+The value of the `TimeAgnostic` type parmater is coupled to [`time_agnostic`](@ref).
 
 Unlike [`SimpleBinary`](@ref), this also contains initial values for its right parent.
 See [Initial values](@ref) for more details.
 """
-struct SimpleBinaryLeftInitial{f,T,R} <: BinaryNodeOp{T,LeftAlignment}
+struct SimpleBinaryLeftInitial{f,TimeAgnostic,T,R} <: BinaryNodeOp{T,LeftAlignment}
     initial_r::R
 end
 
 always_ticks(::SimpleBinaryLeftInitial) = true
 stateless_operator(::SimpleBinaryLeftInitial) = true
-time_agnostic(::SimpleBinaryLeftInitial) = true
-operator!(::SimpleBinaryLeftInitial{f}, x, y) where {f} = f(x, y)
+time_agnostic(::SimpleBinaryLeftInitial{f,false}) where {f} = false
+time_agnostic(::SimpleBinaryLeftInitial{f,true}) where {f} = true
+operator!(::SimpleBinaryLeftInitial{f,false}, t, x, y) where {f} = f(t, x, y)
+operator!(::SimpleBinaryLeftInitial{f,true}, x, y) where {f} = f(x, y)
 has_initial_values(::SimpleBinaryLeftInitial) = true
 initial_right(op::SimpleBinaryLeftInitial) = op.initial_r
 
 """
-    SimpleNary{f,N,T,A}
+    SimpleNary{f,TimeAgnostic,N,T,A}
 
-Represents a stateless, time-independent `N`ary operator that will always emit a value.
+Represents a stateless `N`ary operator that will always emit a value.
+
+The value of the `TimeAgnostic` type parmater is coupled to [`time_agnostic`](@ref).
 """
-struct SimpleNary{f,N,T,A} <: NaryNodeOp{N,T,A} end
+struct SimpleNary{f,TimeAgnostic,N,T,A} <: NaryNodeOp{N,T,A} end
 
 always_ticks(::SimpleNary) = true
 stateless_operator(::SimpleNary) = true
-time_agnostic(::SimpleNary) = true
-operator!(::SimpleNary{f}, values...) where {f} = f(values...)
+time_agnostic(::SimpleNary{f,false}) where {f} = false
+time_agnostic(::SimpleNary{f,true}) where {f} = true
+operator!(::SimpleNary{f,false}, t, values...) where {f} = f(t, values...)
+operator!(::SimpleNary{f,true}, values...) where {f} = f(values...)
 
 """
-    SimpleNaryInitial{f,N,T,A,Types}
+    SimpleNaryInitial{f,TimeAgnostic,N,T,A,Types}
 
-Represents a stateless, time-independent binary operator that will always emit a value.
+Represents a stateless binary operator that will always emit a value.
+
+The value of the `TimeAgnostic` type parmater is coupled to [`time_agnostic`](@ref).
 
 Unlike [`SimpleNary`](@ref), this also contains initial values.
 See [Initial values](@ref) for more details.
 """
-struct SimpleNaryInitial{f,N,T,A,Types} <: NaryNodeOp{N,T,A}
+struct SimpleNaryInitial{f,TimeAgnostic,N,T,A,Types} <: NaryNodeOp{N,T,A}
     initial::Types
 end
 
 always_ticks(::SimpleNaryInitial) = true
 stateless_operator(::SimpleNaryInitial) = true
-time_agnostic(::SimpleNaryInitial) = true
-operator!(::SimpleNaryInitial{f}, values...) where {f} = f(values...)
+time_agnostic(::SimpleNaryInitial{f,false}) where {f} = false
+time_agnostic(::SimpleNaryInitial{f,true}) where {f} = true
+operator!(::SimpleNaryInitial{f,false}, t, values...) where {f} = f(t, values...)
+operator!(::SimpleNaryInitial{f,true}, values...) where {f} = f(values...)
 has_initial_values(::SimpleNaryInitial) = true
 initial_values(op::SimpleNaryInitial) = op.initial
 
 """
-    apply(f::Function, x; out_type=nothing)
+    apply(f::Function, x; out_type=nothing, time_agnostic=true)
     apply(
         f::Function, x, y[, z, ..., alignment=DEFAULT_ALIGNMENT];
-        out_type=nothing, initial_values=nothing
+        out_type=nothing, time_agnostic=true, initial_values=nothing
     )
 
 Obtain a node with values constructed by applying the pure function `f` to the input values.
 
+Iff `time_agnostic` is `false`, `f` will be passed the time of the current knot as the first
+argument, in addition to any values.
+
 With more than one nodal argument, alignment will be performed. In this case, the
 `alignment` argument can be specified as one of [`INTERSECT`](@ref), [`LEFT`](@ref) or
 [`UNION`](@ref). If unspecified, `DEFAULT_ALIGNMENT` will be used.
-
 
 Internally this will infer the output type of `f` applied to the arguments, and will also
 ensure that subgraph elimination occurs when possible.
@@ -114,19 +140,29 @@ If `out_type` is not specified, we attempt to infer the value type of the result
 automatically, using [`output_type`](@ref). Alternatively, if `out_type` is given as
 anything other than `nothing`, it will be used instead.
 """
-function apply(f::Function, x; out_type::Union{Nothing,Type}=nothing)
+function apply(
+    f::Function, x; out_type::Union{Nothing,Type}=nothing, time_agnostic::Bool=true
+)
     x = _ensure_node(x)
-    T = isnothing(out_type) ? output_type(f, value_type(x)) : out_type
-    return obtain_node((x,), SimpleUnary{f,T}())
+    T = if isnothing(out_type)
+        arg_types = (value_type(x),)
+        arg_types = time_agnostic ? arg_types : (DateTime, arg_types...)
+        output_type(f, arg_types...)
+    else
+        out_type
+    end
+    return obtain_node((x,), SimpleUnary{f,time_agnostic,T}())
 end
 
-function _get_op(f, T, ::UnionAlignment, l::L, r::R) where {L,R}
-    return SimpleBinaryUnionInitial{f,T,L,R}(l, r)
+function _get_op(f, time_agnostic, T, ::UnionAlignment, l::L, r::R) where {L,R}
+    return SimpleBinaryUnionInitial{f,time_agnostic,T,L,R}(l, r)
 end
-function _get_op(f, T, ::LeftAlignment, l, r::R) where {R}
-    return SimpleBinaryLeftInitial{f,T,R}(r)
+function _get_op(f, time_agnostic, T, ::LeftAlignment, l, r::R) where {R}
+    return SimpleBinaryLeftInitial{f,time_agnostic,T,R}(r)
 end
-_get_op(f, T, ::IntersectAlignment, l, r) = SimpleBinary{f,T,IntersectAlignment}()
+function _get_op(f, time_agnostic, T, ::IntersectAlignment, l, r)
+    return SimpleBinary{f,time_agnostic,T,IntersectAlignment}()
+end
 
 function apply(
     f::Function,
@@ -135,20 +171,27 @@ function apply(
     alignment::Alignment;
     out_type::Union{Nothing,Type}=nothing,
     initial_values::Union{Nothing,Tuple{<:Any,<:Any}}=nothing,
+    time_agnostic::Bool=true,
 )
     x = _ensure_node(x)
     y = _ensure_node(y)
     A = typeof(alignment)
-    T = isnothing(out_type) ? output_type(f, value_type(x), value_type(y)) : out_type
+    T = if isnothing(out_type)
+        arg_types = (value_type(x), value_type(y))
+        arg_types = time_agnostic ? arg_types : (DateTime, arg_types...)
+        output_type(f, arg_types...)
+    else
+        out_type
+    end
     op = if isnothing(initial_values)
-        SimpleBinary{f,T,A}()
+        SimpleBinary{f,time_agnostic,T,A}()
     else
         initial_l, initial_r = initial_values
         L = value_type(x)
         R = value_type(y)
         isa(initial_l, L) || throw(ArgumentError("$initial_l should be of type $L"))
         isa(initial_r, R) || throw(ArgumentError("$initial_r should be of type $R"))
-        _get_op(f, T, alignment, initial_l, initial_r)
+        _get_op(f, time_agnostic, T, alignment, initial_l, initial_r)
     end
     return obtain_node((x, y), op)
 end
@@ -167,6 +210,7 @@ function apply(
     rest...;
     out_type::Union{Nothing,Type}=nothing,
     initial_values::Union{Nothing,Tuple{Vararg{Any}}}=nothing,
+    time_agnostic::Bool=true,
 )
     # The last argument *might* be an alignment. If it isn't, we should use the default
     # alignment.
@@ -183,18 +227,23 @@ function apply(
     A = typeof(alignment)
     N = length(inputs)
     input_types = map(value_type, inputs)
-    T = isnothing(out_type) ? output_type(f, input_types...) : out_type
+    T = if isnothing(out_type)
+        arg_types = time_agnostic ? input_types : (DateTime, input_types...)
+        output_type(f, arg_types...)
+    else
+        out_type
+    end
     # Note that initial values should always be ignored for intersect alignment, since by
     # definition they will never be used.
     op = if A <: IntersectAlignment || isnothing(initial_values)
-        SimpleNary{f,N,T,A}()
+        SimpleNary{f,time_agnostic,N,T,A}()
     else
         # Sanity check the initial values.
         Types = Tuple{input_types...}
         if !isa(initial_values, Types)
             throw(ArgumentError("$initial_values should be of type $Types"))
         end
-        SimpleNaryInitial{f,N,T,A,Types}(initial_values)
+        SimpleNaryInitial{f,time_agnostic,N,T,A,Types}(initial_values)
     end
     return obtain_node(inputs, op)
 end
@@ -217,33 +266,27 @@ end
 Represent a function that, when called, will expect its arguments to be nodes and try to
 convert them as such.
 """
-struct Wrapped{f} <: Function end
-@inline function (::Wrapped{f})(x, rest...; kwargs...) where {f}
-    # args = (x, rest...)
-    # # In order to support nary functions, `apply` takes the alignment as the first argument.
-    # # Currently the rest of our API expects alignment as the last argument (as this makes
-    # # specifying a default easier in general).
-    # head = args[1:end - 1]
-    # tail = last(args)
-    # args, alignment = if isa(tail, Alignment)
-    #     head, tail
-    # else
-    #     args, DEFAULT_ALIGNMENT
-    # end
-    return apply(f, x, rest...; kwargs...)
+struct Wrapped{f} <: Function
+    time_agnostic::Bool
+end
+@inline function (wrapped::Wrapped{f})(x, rest...; kwargs...) where {f}
+    return apply(f, x, rest...; time_agnostic=wrapped.time_agnostic, kwargs...)
 end
 
 # TODO Would we like an identity map? Not important right now, but could be in the future
 #   if we allow stateful things?
 
 """
-    wrap(f::Function)
+    wrap(f::Function; time_agnostic=true)
 
 Return a callable object that acts on nodes, and returns a node.
 
-It is assumed that `f` is stateless and time-independent. We also assume that we will
-always emit a knot when the alignment semantics say we should — thus `f` must always return
-a valid output value.
+It is assumed that `f` is stateless (this will therefore not work with closures). We also
+assume that we will always emit a knot when the alignment semantics say we should — thus `f`
+must always return a valid output value.
+
+Iff `time_agnostic` is `false`, `f` will be passed the time of the current knot as the first
+argument, followed by the value of every input.
 
 If the object is called with more than one node, alignment will be performed.
 If an alignment other than the default should be used, provide it as the final argument.
@@ -251,14 +294,14 @@ If an alignment other than the default should be used, provide it as the final a
 Internally this will call `TimeDag.apply(f, args...; kwargs...)`; see there for further
 details.
 """
-wrap(f::Function) = Wrapped{f}()
+wrap(f::Function; time_agnostic::Bool=true) = Wrapped{f}(time_agnostic)
 
 """
     wrapb(f::Function)
 
 `wrapb` is like [`wrap`](@ref), however `f` will be broadcasted over all input values.
 """
-wrapb(f::Function) = Wrapped{BCast(f)}()
+wrapb(f::Function; time_agnostic::Bool=true) = Wrapped{BCast(f)}(time_agnostic)
 
 """
     @simple_unary(f)

--- a/test/common.jl
+++ b/test/common.jl
@@ -48,9 +48,9 @@ function _evaluate(node::Node, t0::DateTime, t1::DateTime)
 end
 
 """
-Map the given function over each of the block's values.
+Map the given function over each of the block's times & values.
 """
-_mapvalues(f, block::Block) = Block([time => f(value) for (time, value) in block])
+_map(f, block::Block) = Block([time => f(time, value) for (time, value) in block])
 
 # Common functionality for testing binary operators that also perform alignment.
 # Disable formatting, so as to permit more consistent layout of timeseries.
@@ -124,35 +124,43 @@ function _get_rand_vec_block(rng::AbstractRNG, dim::Int, n_obs::Int)
     return Block(times, values)
 end
 
-function _test_unary_op(f_timedag, block::Block, f=f_timedag)
+function _test_unary_op(f_timedag, block::Block, f=f_timedag; time_agnostic::Bool=true)
+    ft = time_agnostic ? (_, x) -> f(x) : f
+
     # Check basic evaluation.
     value = first(block.values)
     node = block_node(block)
-    @test _eval(f_timedag(node)) == _mapvalues(f, block)
+    @test _eval(f_timedag(node)) == _map(ft, block)
 
-    # Check constant propagation.
-    @test f_timedag(constant(value)) == constant(f(value))
-    @test f_timedag(constant(value)) === constant(f(value))
+    if time_agnostic
+        # Check constant propagation (only relevant for time agnostic nodes).
+        @test f_timedag(constant(value)) == constant(f(value))
+        @test f_timedag(constant(value)) === constant(f(value))
+    end
 
     # Two instances of the NodeOp instance should compare equal for equal
     # type parameters.
     T = typeof(value)
-    @test TimeDag.SimpleUnary{f,T}() == TimeDag.SimpleUnary{f,T}()
     @test T != Float32
-    @test TimeDag.SimpleUnary{f,Float32}() != TimeDag.SimpleUnary{f,T}()
+    for ta in (true, false)
+        @test TimeDag.SimpleUnary{f,ta,T}() == TimeDag.SimpleUnary{f,ta,T}()
+        @test TimeDag.SimpleUnary{f,ta,Float32}() != TimeDag.SimpleUnary{f,ta,T}()
+    end
 end
 
-function _test_binary_op(f_timedag, f=f_timedag)
+function _test_binary_op(f_timedag, f=f_timedag; time_agnostic::Bool=true)
+    ft = time_agnostic ? (_, x, y) -> f(x, y) : f
+
     @testset "Common (fast) alignment" begin
         # Should apply for *any* user choice of alignment.
         for alignment in (UNION, LEFT, INTERSECT)
             n = f_timedag(n1, n1, alignment)
             block = _eval(n)
             @test block == Block([
-                DateTime(2000, 1, 1) => f(1, 1),
-                DateTime(2000, 1, 2) => f(2, 2),
-                DateTime(2000, 1, 3) => f(3, 3),
-                DateTime(2000, 1, 4) => f(4, 4),
+                DateTime(2000, 1, 1) => ft(DateTime(2000, 1, 1), 1, 1),
+                DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 2),
+                DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 3),
+                DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 4),
             ])
             # For fast alignment, we expect *identical* timestamps as on the input.
             @test block.times === b1.times
@@ -164,10 +172,10 @@ function _test_binary_op(f_timedag, f=f_timedag)
         @test n === f_timedag(n1, n2, UNION)
         block = _eval(n)
         @test block == Block([
-            DateTime(2000, 1, 2) => f(2, 5),
-            DateTime(2000, 1, 3) => f(3, 6),
-            DateTime(2000, 1, 4) => f(4, 6),
-            DateTime(2000, 1, 5) => f(4, 8),
+            DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5),
+            DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6),
+            DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 6),
+            DateTime(2000, 1, 5) => ft(DateTime(2000, 1, 5), 4, 8),
         ])
     end
 
@@ -175,42 +183,45 @@ function _test_binary_op(f_timedag, f=f_timedag)
         n = f_timedag(n1, n2, INTERSECT)
 
         @test _eval(n) == Block([
-            DateTime(2000, 1, 2) => f(2, 5),
-            DateTime(2000, 1, 3) => f(3, 6),
+            DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5),
+            DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6),
         ])
     end
 
     @testset "left alignment" begin
         n = f_timedag(n1, n2, LEFT)
         @test _eval(n) == Block([
-            DateTime(2000, 1, 2) => f(2, 5),
-            DateTime(2000, 1, 3) => f(3, 6),
-            DateTime(2000, 1, 4) => f(4, 6),
+            DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5),
+            DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6),
+            DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 6),
         ])
 
         # Catch edge-case in which there was a bug.
         @test _eval(f_timedag(n2, n3, LEFT)) == Block([
-            DateTime(2000, 1, 2) => f(5, 15),
-            DateTime(2000, 1, 3) => f(6, 15),
-            DateTime(2000, 1, 5) => f(8, 15),
+            DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 5, 15),
+            DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 6, 15),
+            DateTime(2000, 1, 5) => ft(DateTime(2000, 1, 5), 8, 15),
         ])
         @test _eval(f_timedag(n3, n2, LEFT)) == Block{Int64}()
     end
 
-    @testset "constant propagation" begin
-        value = 2.0  # valid for all ops we're currently testing.
-        @test f_timedag(constant(value), constant(value)) === constant(f(value, value))
-        @test f_timedag(value, constant(value)) === constant(f(value, value))
-        @test f_timedag(constant(value), value) === constant(f(value, value))
+    if time_agnostic
+        @testset "constant propagation" begin
+            value = 2.0  # valid for all ops we're currently testing.
+            @test f_timedag(constant(value), constant(value)) === constant(f(value, value))
+            @test f_timedag(value, constant(value)) === constant(f(value, value))
+            @test f_timedag(constant(value), value) === constant(f(value, value))
+        end
     end
 
     # Two instances of the NodeOp instance should compare equal for equal
     # type parameters.
     T = Float64
     for A in (UnionAlignment, IntersectAlignment, LeftAlignment)
-        @test TimeDag.SimpleBinary{f,T,A}() == TimeDag.SimpleBinary{f,T,A}()
-        @test T != Float32
-        @test TimeDag.SimpleBinary{f,Float32,A}() != TimeDag.SimpleBinary{f,T,A}()
+        for ta in (true, false)
+            @test TimeDag.SimpleBinary{f,ta,T,A}() == TimeDag.SimpleBinary{f,ta,T,A}()
+            @test TimeDag.SimpleBinary{f,ta,Float32,A}() != TimeDag.SimpleBinary{f,ta,T,A}()
+        end
     end
 
     @testset "initial values" begin
@@ -222,20 +233,20 @@ function _test_binary_op(f_timedag, f=f_timedag)
             @test n === f_timedag(n1, n2, UNION; initial_values=(-1, -2))
 
             @test _eval(n) == Block([
-                DateTime(2000, 1, 1) => f(1, -2),
-                DateTime(2000, 1, 2) => f(2, 5),
-                DateTime(2000, 1, 3) => f(3, 6),
-                DateTime(2000, 1, 4) => f(4, 6),
-                DateTime(2000, 1, 5) => f(4, 8),
+                DateTime(2000, 1, 1) => ft(DateTime(2000, 1, 1), 1, -2),
+                DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5),
+                DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6),
+                DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 6),
+                DateTime(2000, 1, 5) => ft(DateTime(2000, 1, 5), 4, 8),
             ])
 
             n = f_timedag(n2, n1; initial_values=(-1, -2))
             @test _eval(n) == Block([
-                DateTime(2000, 1, 1) => f(-1, 1),
-                DateTime(2000, 1, 2) => f(5, 2),
-                DateTime(2000, 1, 3) => f(6, 3),
-                DateTime(2000, 1, 4) => f(6, 4),
-                DateTime(2000, 1, 5) => f(8, 4),
+                DateTime(2000, 1, 1) => ft(DateTime(2000, 1, 1), -1, 1),
+                DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 5, 2),
+                DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 6, 3),
+                DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 6, 4),
+                DateTime(2000, 1, 5) => ft(DateTime(2000, 1, 5), 8, 4),
             ])
         end
 
@@ -244,10 +255,10 @@ function _test_binary_op(f_timedag, f=f_timedag)
             # Initial left value should be ignored.
             @test n === f_timedag(n1, n2, LEFT; initial_values=(-42, -2))
             @test _eval(n) == Block([
-                DateTime(2000, 1, 1) => f(1, -2),
-                DateTime(2000, 1, 2) => f(2, 5),
-                DateTime(2000, 1, 3) => f(3, 6),
-                DateTime(2000, 1, 4) => f(4, 6),
+                DateTime(2000, 1, 1) => ft(DateTime(2000, 1, 1), 1, -2),
+                DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5),
+                DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6),
+                DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 6),
             ])
         end
 
@@ -260,17 +271,19 @@ function _test_binary_op(f_timedag, f=f_timedag)
     end
 end
 
-function _test_ternary_op(f_timedag, f=f_timedag)
+function _test_ternary_op(f_timedag, f=f_timedag; time_agnostic::Bool=true)
+    ft = time_agnostic ? (_, x, y, z) -> f(x, y, z) : f
+
     @testset "Common (fast) alignment" begin
         # Should apply for *any* user choice of alignment.
         for alignment in (UNION, LEFT, INTERSECT)
             n = f_timedag(n1, n1, n1, alignment)
             block = _eval(n)
             @test block == Block([
-                DateTime(2000, 1, 1) => f(1, 1, 1),
-                DateTime(2000, 1, 2) => f(2, 2, 2),
-                DateTime(2000, 1, 3) => f(3, 3, 3),
-                DateTime(2000, 1, 4) => f(4, 4, 4),
+                DateTime(2000, 1, 1) => ft(DateTime(2000, 1, 1), 1, 1, 1),
+                DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 2, 2),
+                DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 3, 3),
+                DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 4, 4),
             ])
             # For fast alignment, we expect *identical* timestamps as on the input.
             @test block.times === b1.times
@@ -282,10 +295,10 @@ function _test_ternary_op(f_timedag, f=f_timedag)
         @test n === f_timedag(n1, n2, n3, UNION)
         block = _eval(n)
         @test block == Block([
-            DateTime(2000, 1, 2) => f(2, 5, 15),
-            DateTime(2000, 1, 3) => f(3, 6, 15),
-            DateTime(2000, 1, 4) => f(4, 6, 15),
-            DateTime(2000, 1, 5) => f(4, 8, 15),
+            DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5, 15),
+            DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6, 15),
+            DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 6, 15),
+            DateTime(2000, 1, 5) => ft(DateTime(2000, 1, 5), 4, 8, 15),
         ])
     end
 
@@ -293,48 +306,51 @@ function _test_ternary_op(f_timedag, f=f_timedag)
         n = f_timedag(n1, n2, n4, INTERSECT)
 
         @test _eval(n) == Block([
-            DateTime(2000, 1, 2) => f(2, 5, 2),
-            DateTime(2000, 1, 3) => f(3, 6, 3),
+            DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5, 2),
+            DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6, 3),
         ])
     end
 
     @testset "left alignment" begin
         n = f_timedag(n1, n2, n3, LEFT)
         @test _eval(n) == Block([
-            DateTime(2000, 1, 2) => f(2, 5, 15),
-            DateTime(2000, 1, 3) => f(3, 6, 15),
-            DateTime(2000, 1, 4) => f(4, 6, 15),
+            DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5, 15),
+            DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6, 15),
+            DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 6, 15),
         ])
 
         # Catch edge-case in which there was a bug.
         @test _eval(f_timedag(n2, n3, n1, LEFT)) == Block([
-            DateTime(2000, 1, 2) => f(5, 15, 2),
-            DateTime(2000, 1, 3) => f(6, 15, 3),
-            DateTime(2000, 1, 5) => f(8, 15, 4),
+            DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 5, 15, 2),
+            DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 6, 15, 3),
+            DateTime(2000, 1, 5) => ft(DateTime(2000, 1, 5), 8, 15, 4),
         ])
         @test _eval(f_timedag(n3, n2, n1, LEFT)) == Block{Int64}()
     end
 
-    @testset "constant propagation" begin
-        value = 2.0  # valid for all ops we're currently testing.
-        cv = constant(value)
-        cf = constant(f(value, value, value))
-        @test f_timedag(cv, cv, cv) === cf
-        @test f_timedag(cv, value, value) === cf
-        @test f_timedag(value, cv, value) === cf
-        @test f_timedag(value, value, cv) === cf
-        @test f_timedag(cv, cv, value) === cf
-        @test f_timedag(cv, value, cv) === cf
-        @test f_timedag(value, cv, cv) === cf
+    if time_agnostic
+        @testset "constant propagation" begin
+            value = 2.0  # valid for all ops we're currently testing.
+            cv = constant(value)
+            cf = constant(f(value, value, value))
+            @test f_timedag(cv, cv, cv) === cf
+            @test f_timedag(cv, value, value) === cf
+            @test f_timedag(value, cv, value) === cf
+            @test f_timedag(value, value, cv) === cf
+            @test f_timedag(cv, cv, value) === cf
+            @test f_timedag(cv, value, cv) === cf
+            @test f_timedag(value, cv, cv) === cf
+        end
     end
 
     # Two instances of the NodeOp instance should compare equal for equal
     # type parameters.
     T = Float64
     for A in (UnionAlignment, IntersectAlignment, LeftAlignment)
-        @test TimeDag.SimpleNary{f,3,T,A}() == TimeDag.SimpleNary{f,3,T,A}()
-        @test T != Float32
-        @test TimeDag.SimpleNary{f,3,Float32,A}() != TimeDag.SimpleNary{f,3,T,A}()
+        for ta in (true, false)
+            @test TimeDag.SimpleNary{f,ta,3,T,A}() == TimeDag.SimpleNary{f,ta,3,T,A}()
+            @test TimeDag.SimpleNary{f,ta,3,Float32,A}() != TimeDag.SimpleNary{f,ta,3,T,A}()
+        end
     end
 
     @testset "initial values" begin
@@ -346,20 +362,20 @@ function _test_ternary_op(f_timedag, f=f_timedag)
             @test n === f_timedag(n1, n2, n3, UNION; initial_values=(-1, -2, -3))
 
             @test _eval(n) == Block([
-                DateTime(2000, 1, 1) => f(1, -2, 15),
-                DateTime(2000, 1, 2) => f(2, 5, 15),
-                DateTime(2000, 1, 3) => f(3, 6, 15),
-                DateTime(2000, 1, 4) => f(4, 6, 15),
-                DateTime(2000, 1, 5) => f(4, 8, 15),
+                DateTime(2000, 1, 1) => ft(DateTime(2000, 1, 1), 1, -2, 15),
+                DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5, 15),
+                DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6, 15),
+                DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 6, 15),
+                DateTime(2000, 1, 5) => ft(DateTime(2000, 1, 5), 4, 8, 15),
             ])
 
             n = f_timedag(n2, n1, n3; initial_values=(-1, -2, -3))
             @test _eval(n) == Block([
-                DateTime(2000, 1, 1) => f(-1, 1, 15),
-                DateTime(2000, 1, 2) => f(5, 2, 15),
-                DateTime(2000, 1, 3) => f(6, 3, 15),
-                DateTime(2000, 1, 4) => f(6, 4, 15),
-                DateTime(2000, 1, 5) => f(8, 4, 15),
+                DateTime(2000, 1, 1) => ft(DateTime(2000, 1, 1), -1, 1, 15),
+                DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 5, 2, 15),
+                DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 6, 3, 15),
+                DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 6, 4, 15),
+                DateTime(2000, 1, 5) => ft(DateTime(2000, 1, 5), 8, 4, 15),
             ])
         end
 
@@ -369,10 +385,10 @@ function _test_ternary_op(f_timedag, f=f_timedag)
             # # Initial left value should be ignored.
             # @test n === f_timedag(n1, n2, n3, LEFT; initial_values=(-42, -2, -3))
             @test _eval(n) == Block([
-                DateTime(2000, 1, 1) => f(1, -2, 15),
-                DateTime(2000, 1, 2) => f(2, 5, 15),
-                DateTime(2000, 1, 3) => f(3, 6, 15),
-                DateTime(2000, 1, 4) => f(4, 6, 15),
+                DateTime(2000, 1, 1) => ft(DateTime(2000, 1, 1), 1, -2, 15),
+                DateTime(2000, 1, 2) => ft(DateTime(2000, 1, 2), 2, 5, 15),
+                DateTime(2000, 1, 3) => ft(DateTime(2000, 1, 3), 3, 6, 15),
+                DateTime(2000, 1, 4) => ft(DateTime(2000, 1, 4), 4, 6, 15),
             ])
         end
 

--- a/test/ops/common.jl
+++ b/test/ops/common.jl
@@ -2,16 +2,25 @@
     @testset "unary" begin
         f(x) = x + 1
         _test_unary_op(wrap(f), b4, f)
+
+        g(t, x) = t > _T_START + Day(2) ? x + 1 : x + 2
+        _test_unary_op(wrap(g; time_agnostic=false), b4, g; time_agnostic=false)
     end
 
     @testset "binary" begin
         f(x, y) = x + y + 1
         _test_binary_op(wrap(f), f)
+
+        g(t, x, y) = t > _T_START + Day(2) ? x + y + 1 : x + y + 2
+        _test_binary_op(wrap(g; time_agnostic=false), g; time_agnostic=false)
     end
 
     @testset "ternary" begin
         f(x, y, z) = x + y + 1 - z
         _test_ternary_op(wrap(f), f)
+
+        g(t, x, y, z) = t > _T_START + Day(2) ? x + y + 1 - z : x + y + 2 - z
+        _test_ternary_op(wrap(g; time_agnostic=false), g; time_agnostic=false)
     end
 end
 
@@ -30,6 +39,10 @@ end
         f(x) = x + 3
         f_broadcast(x) = f.(x)
         _test_unary_op(wrapb(f), ba, f_broadcast)
+
+        g(t, x) = t > _T_START + Day(2) ? x + 3 : x + 4
+        g_broadcast(t, x) = t > _T_START + Day(2) ? x .+ 3 : x .+ 4
+        _test_unary_op(wrapb(g; time_agnostic=false), ba, g_broadcast; time_agnostic=false)
     end
 
     @testset "binary" begin


### PR DESCRIPTION
This exposes the `time_agnostic` functionality to users of `wrap` and `wrapb` (previously only time-independent functions could be wrapped in this way)